### PR TITLE
feature: add ingress aws load balancer controller, enable eks logs, add eks openid connect provider, tag subnets

### DIFF
--- a/_provider.tf
+++ b/_provider.tf
@@ -7,6 +7,16 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 4.0"
     }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~>2.12"
+    }
+
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~>2.6"
+    }
   }
 }
 
@@ -18,5 +28,23 @@ provider "aws" {
       Environment = "<myenv>"
       Owner       = "<myname>"
     }
+  }
+}
+
+data "aws_eks_cluster_auth" "eks_cluster" {
+  name = aws_eks_cluster.eks_cluster.name
+}
+
+provider "kubernetes" {
+  host                   = aws_eks_cluster.eks_cluster.endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.eks_cluster.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.eks_cluster.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = aws_eks_cluster.eks_cluster.endpoint
+    cluster_ca_certificate = base64decode(aws_eks_cluster.eks_cluster.certificate_authority[0].data)
+    token                  = data.aws_eks_cluster_auth.eks_cluster.token
   }
 }

--- a/aws_load_balancer_controller.tf
+++ b/aws_load_balancer_controller.tf
@@ -1,0 +1,51 @@
+resource "kubernetes_service_account_v1" "aws_load_balancer_controller" {
+  metadata {
+    labels = {
+      "app.kubernetes.io/name" = local.ingress_alb_controller.name
+    }
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.aws_load_balancer_controller.arn
+    }
+
+    name      = local.ingress_alb_controller.name
+    namespace = local.ingress_alb_controller.namespace
+  }
+}
+
+resource "helm_release" "aws_load_balancer_controller" {
+  name       = local.ingress_alb_controller.name
+  repository = local.ingress_alb_controller.helm.repository
+  chart      = local.ingress_alb_controller.helm.chart.name
+  version    = local.ingress_alb_controller.helm.chart.version
+  namespace  = local.ingress_alb_controller.namespace
+
+  set {
+    name  = "clusterName"
+    value = local.ingress_alb_controller.helm.chart.values.clusterName
+  }
+
+  set {
+    name  = "serviceAccount.create"
+    value = local.ingress_alb_controller.helm.chart.values.serviceAccount_create
+  }
+
+  set {
+    name  = "serviceAccount.name"
+    value = local.ingress_alb_controller.helm.chart.values.serviceAccount_name
+  }
+
+  set {
+    name  = "vpcId"
+    value = local.ingress_alb_controller.helm.chart.values.vpcId
+  }
+
+  set {
+    name  = "region"
+    value = local.ingress_alb_controller.helm.chart.values.region
+  }
+
+  depends_on = [
+    aws_eks_cluster.eks_cluster,
+    aws_iam_role.aws_load_balancer_controller
+  ]
+}

--- a/iam.tf
+++ b/iam.tf
@@ -55,3 +55,277 @@ resource "aws_iam_role_policy_attachment" "eks_cluster_node_group_AmazonEC2Conta
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   role       = aws_iam_role.eks_cluster_node_group.name
 }
+
+resource "aws_iam_role" "aws_load_balancer_controller" {
+  assume_role_policy = jsonencode({
+    Version : "2012-10-17",
+    Statement : [
+      {
+        Effect : "Allow",
+        Condition : {
+          StringEquals : {
+            "${replace(aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer, "https://", "")}:aud" : "sts.amazonaws.com",
+            "${replace(aws_eks_cluster.eks_cluster.identity[0].oidc[0].issuer, "https://", "")}:sub" : "system:serviceaccount:${local.ingress_alb_controller.namespace}:${local.ingress_alb_controller.name}"
+          }
+        },
+        Principal : {
+          Federated : "${aws_iam_openid_connect_provider.eks_cluster.arn}"
+        },
+        Action : "sts:AssumeRoleWithWebIdentity"
+      }
+    ]
+    }
+
+  )
+
+  name = "${var.env}-${local.ingress_alb_controller.name}-role"
+}
+
+resource "aws_iam_role_policy" "aws_load_balancer_controller" {
+  name = "${var.env}-${local.ingress_alb_controller.name}-policy"
+  role = aws_iam_role.aws_load_balancer_controller.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}

--- a/locals.tf
+++ b/locals.tf
@@ -26,4 +26,25 @@ locals {
   }
 
   eks_node_group_sg_name = "${local.eks_node_group.name}-sg"
+
+  ingress_alb_controller = {
+    name      = "aws-load-balancer-controller"
+    namespace = "kube-system"
+
+    helm = {
+      repository = "https://aws.github.io/eks-charts"
+      chart = {
+        name    = "aws-load-balancer-controller"
+        version = "1.5.4"
+
+        values = {
+          clusterName           = aws_eks_cluster.eks_cluster.name
+          serviceAccount_name   = "aws-load-balancer-controller"
+          serviceAccount_create = "false"
+          vpcId                 = aws_vpc.eks_cluster_vpc.id
+          region                = "ap-southeast-2"
+        }
+      }
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,4 @@
 variable "env" {
   type        = string
   description = "The name of the environment where this project is being run. eg dev, test, preprod, prod."
-  default     = "dev"
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -26,7 +26,8 @@ resource "aws_subnet" "eks_cluster_vpc_public_subnets" {
   map_public_ip_on_launch = false
 
   tags = {
-    Name = "public-subnet${count.index}-${data.aws_availability_zones.available.zone_ids[count.index]}"
+    Name                     = "public-subnet${count.index}-${data.aws_availability_zones.available.zone_ids[count.index]}"
+    "kubernetes.io/role/elb" = 1
   }
 }
 
@@ -38,7 +39,8 @@ resource "aws_subnet" "eks_cluster_vpc_private_subnets" {
   vpc_id            = aws_vpc.eks_cluster_vpc.id
 
   tags = {
-    Name = "private-subnet${count.index}-${data.aws_availability_zones.available.zone_ids[count.index]}"
+    Name                              = "private-subnet${count.index}-${data.aws_availability_zones.available.zone_ids[count.index]}"
+    "kubernetes.io/role/internal-elb" = 1
   }
 }
 


### PR DESCRIPTION
## Summary

This pull request contains the following changes.
- it adds an ingress aws load balancer controller to the kubernetes cluster.
- it tags the subnets with "kubernetes.io/role/elb" or "kubernetes.io/role/internal-elb" to denote which subnets are internal and which are internet-facing.
- it adds an openid connect provider to the Amazon EKS cluster, which will allow the usage of AWS IAM roles with service accounts in the kubernetes cluster.
- it enables the following Amazon EKS logs
  - api
  - audit
  - authenticator
  - controllerManager
  - scheduler